### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ '*' ]


### PR DESCRIPTION
Potential fix for [https://github.com/zxenonx/zc_messaging/security/code-scanning/1](https://github.com/zxenonx/zc_messaging/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow does not appear to require write permissions, the `contents: read` permission is sufficient. This limits the `GITHUB_TOKEN` to read-only access to repository contents, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
